### PR TITLE
update the GoDoc badge to https:// and .svg URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HttpPath [![Build Status](https://travis-ci.org/dimfeld/httppath.png?branch=master)](https://travis-ci.org/dimfeld/httppath) [![GoDoc](http://godoc.org/github.com/dimfeld/httppath?status.png)](http://godoc.org/github.com/dimfeld/httppath)
+# HttpPath [![Build Status](https://travis-ci.org/dimfeld/httppath.png?branch=master)](https://travis-ci.org/dimfeld/httppath) [![GoDoc](https://godoc.org/github.com/dimfeld/httppath?status.svg)](https://godoc.org/github.com/dimfeld/httppath)
 
 Utilities for HTTP Path manipulation.  
 


### PR DESCRIPTION
copied the Markdown for the GoDoc badge from https://godoc.org/github.com/dimfeld/httppath?tools